### PR TITLE
Fixed building issue

### DIFF
--- a/src/util/excalidraw.init.data.ts
+++ b/src/util/excalidraw.init.data.ts
@@ -1,7 +1,7 @@
 import { ExcalidrawContent } from '../excalidraw-backend/types';
 
 export const excalidrawInitContent: ExcalidrawContent = {
-  appState: undefined,
+  appState: {},
   source: '',
   type: 'excalidraw',
   version: 1,


### PR DESCRIPTION
Fixed `src/util/excalidraw.init.data.ts:4:3 - error TS2322: Type 'undefined' is not assignable to type 'Record<string, unknown>'.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the initialization of the app state in Excalidraw to ensure it starts as an empty object, improving stability and preventing potential errors related to undefined states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->