### PR TITLE
Element sorting handling inserted templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "whiteboard-collaboration-service",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "whiteboard-collaboration-service",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "EUPL-1.2",
       "dependencies": {
         "@nestjs/common": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whiteboard-collaboration-service",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Alkemio Whiteboard Collaboration Service for Excalidraw backend",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/excalidraw-backend/utils/reconcile.ts
+++ b/src/excalidraw-backend/utils/reconcile.ts
@@ -140,8 +140,15 @@ const tryOrderByPrecedingElement = (
   // the array is starting with element that has no preceding element
   let parentElement = startElements[0];
   orderedElements.push(parentElement);
+  // keep track of visited elements to prevent cycles
+  const visitedElements = new Set<string>();
   // Follow the chain of __precedingElement__ until we have sorted all
   while (orderedElements.length != unOrderedElements.length) {
+    // prevent cycles in the chain
+    if (visitedElements.has(parentElement.id)) {
+      throw new Error('Cycle detected in __precedingElement__ chain');
+    }
+    visitedElements.add(parentElement.id);
     // a child of a parent, is an element which __precedingElement__ is pointing to the parent
     // is there an element which preceding element is the parent element
     const childElement = elementMapByPrecedingKey.get(parentElement.id);

--- a/src/excalidraw-backend/utils/reconcile.ts
+++ b/src/excalidraw-backend/utils/reconcile.ts
@@ -1,7 +1,8 @@
+import { Logger } from '@nestjs/common';
+import { unionBy } from 'lodash';
 import { arrayToMap } from './array.to.map';
 import { ExcalidrawElement } from '../../excalidraw/types';
 import { arrayToMapBy } from './array.to.map.by';
-import { Logger } from '@nestjs/common';
 // import { orderByFractionalIndex, syncInvalidIndices } from './fractionalIndex';
 
 const shouldDiscardRemoteElement = (
@@ -97,20 +98,28 @@ export const reconcileElements = (
   // de-duplicate indices
   // const syncedElemented = syncInvalidIndices(orderedElements);
   try {
-    return orderByPrecedingElement(reconciledElements);
+    return tryOrderByPrecedingElement(reconciledElements);
   } catch (error) {
     logger.warn(`Element sorting failed with error: '${error.message}'`);
     return reconciledElements;
   }
 };
 
-const orderByPrecedingElement = (
+/**
+ * Will try to order elements by preceding element.
+ * Order is not guaranteed, if there are multiple "first" elements, or a preceding element that does not exist.
+ * Returns a half sorted array if there is an element with preceding element that does not exist.
+ * @param unOrderedElements
+ * @throws Error if there is more than one element with preceding element = '^'
+ */
+const tryOrderByPrecedingElement = (
   unOrderedElements: ExcalidrawElement[],
 ): ExcalidrawElement[] | never => {
   // for zero or one element return the same array, as it's already sorted
   if (unOrderedElements.length < 2) {
     return unOrderedElements;
   }
+  // const elementsWithPreceding = unOrderedElements.filter(el.
   // validated there is just one starting element
   const startElements = unOrderedElements.filter(
     (el) => el.__precedingElement__ === '^',
@@ -131,14 +140,17 @@ const orderByPrecedingElement = (
   // the array is starting with element that has no preceding element
   let parentElement = startElements[0];
   orderedElements.push(parentElement);
-  // Follow the chain of __precedingElement__
-  while (true) {
+  // Follow the chain of __precedingElement__ until we have sorted all
+  while (orderedElements.length != unOrderedElements.length) {
+    // a child of a parent, is an element which __precedingElement__ is pointing to the parent
+    // is there an element which preceding element is the parent element
     const childElement = elementMapByPrecedingKey.get(parentElement.id);
-
+    // there is a parent, which has no child; the chain is broken
     if (!childElement) {
-      // we have reached the end of the chain
-      break;
+      // switch both arrays; combine ordered and switch the unordered at the end
+      return unionBy(orderedElements, unOrderedElements, 'id');
     }
+    // the final element is pointing to the one before it (preceding element)
 
     orderedElements.push(childElement);
     parentElement = childElement;


### PR DESCRIPTION
When a template is inserted, it's pasting a new whiteboard B on top of the existing one A.
A maybe sorted, but locally sorted, with a preceding element that does not exist, or is locally first (rendered first).
In this way you end up with two (maybe sorted arrays) that have to be combined, but the chain of preceding element is broken.

As a solution, when the chain breaks the unsorted elements are concatenated to the sorted elements. You end up with a half-sorted array, but without losing any elements.

 In rear cases, users can experience elements on top of each other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced room data saving with improved reliability and error handling.
	- Introduced a new method for better handling of element sorting and reconciliation.

- **Bug Fixes**
	- Improved error handling for room saving operations, providing clearer feedback on success or failure.

- **Documentation**
	- Enhanced documentation for new and modified methods to improve user understanding.

- **Chores**
	- Updated version number to 0.4.2 in the package.json file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->