### PR TITLE
Add arm64 architecture support to Docker builds

### DIFF
--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read    # Required for actions/checkout
+      actions: write    # Required for cache-to: type=gha
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.10.0
         with:
           # Image name derived from repo name (e.g., alkemio/whiteboard-collaboration-service)
           images: alkemio/${{ github.event.repository.name }}
@@ -29,19 +29,19 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -1,3 +1,6 @@
+# Builds and publishes multi-architecture Docker images to Docker Hub.
+# Triggered only on GitHub releases (not PRs or pushes), so push/login
+# operations are always safe to execute unconditionally.
 name: Deploy to DockerHub
 
 on:
@@ -15,11 +18,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
+          # Image name derived from repo name (e.g., alkemio/whiteboard-collaboration-service)
           images: alkemio/${{ github.event.repository.name }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
+            # Only tag as 'latest' for stable releases, not prereleases
             type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
             type=sha,prefix=sha-
 

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -9,60 +9,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=alkemio/whiteboard-collaboration-service
-          VERSION=noop
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            VERSION=nightly
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=edge
-            fi
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            MINOR=${VERSION%.*}
-            MAJOR=${MINOR%.*}
-            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
-          fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-          echo "created={$(date -u +'%Y-%m-%dT%H:%M:%SZ')}" >> $GITHUB_OUTPUT
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: alkemio/${{ github.event.repository.name }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
+            type=sha,prefix=sha-
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GitHub Actions cache for faster builds
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # SLSA provenance attestation for supply chain security
+          provenance: mode=max
+          # A machine-readable inventory of all components, libraries, and dependencies in your container image. It lists package names, versions,
+          #  and licenses. Useful for:
+          #  - Security scanning (quickly check if you're affected by a CVE)
+          #  - Compliance audits
+          #  - Supply chain transparency
+          sbom: true


### PR DESCRIPTION
## Summary
- Update build-release-docker-hub workflow to build multi-architecture Docker images
- Images now support both `linux/amd64` and `linux/arm64` platforms
- Enables native execution on ARM-based systems (Apple Silicon, AWS Graviton, etc.)

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Trigger a release and confirm both architectures are built
- [ ] Pull image on amd64 and arm64 systems to verify correct architecture is served

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image build workflow with multi-platform support (AMD64, ARM64), unconditional pushing, and SHA-based tagging
  * Switched to metadata-driven image tagging and dynamic labels (replacing manual tag scripting)
  * Updated CI build steps and tooling for improved QEMU/Buildx support and login handling
  * Added build caching, automated SBOM generation, and SLSA provenance for produced images

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->