### PR TITLE
Remove email from user identity, use ID for logging and tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+.claude/settings.local.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whiteboard-collaboration-service",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Alkemio Whiteboard Collaboration Service for Excalidraw backend",
   "author": "Alkemio Foundation",
   "private": false,

--- a/src/excalidraw-backend/middlewares/init.user.data.middleware.ts
+++ b/src/excalidraw-backend/middlewares/init.user.data.middleware.ts
@@ -8,7 +8,6 @@ export const initUserDataMiddleware: SimpleMiddlewareHandler = (
 ) => {
   socket.data.userInfo = {
     id: 'not-initialized',
-    email: 'not-initialized',
     guestName: 'not-initialized',
   };
   socket.data.lastContributed = -1;

--- a/src/excalidraw-backend/server.ts
+++ b/src/excalidraw-backend/server.ts
@@ -213,7 +213,7 @@ export class Server {
 
     this.wsServer.on(CONNECTION, async (socket: SocketIoSocket) => {
       this.logger.verbose?.(
-        `User '${socket.data.userInfo.email}' established connection`,
+        `User '${socket.data.userInfo.id}' established connection`,
       );
 
       socket.on(PING, (ack) => ack());
@@ -243,13 +243,13 @@ export class Server {
         } catch (e: any) {
           if (e instanceof UnauthorizedReadAccess) {
             this.logger.warn?.(
-              `User '${socket.data.userInfo.email}' insufficient read access to Whiteboard: '${roomID}'`,
+              `User '${socket.data.userInfo.id}' insufficient read access to Whiteboard: '${roomID}'`,
             );
             closeConnectionWithError(socket, ERROR_EVENTS.ROOM_NO_READ_ACCESS);
             return;
           }
           this.logger.error(
-            `Error while trying to authorize User '${socket.data.userInfo.email}' with Whiteboard: '${roomID}'`,
+            `Error while trying to authorize User '${socket.data.userInfo.id}' with Whiteboard: '${roomID}'`,
             e.stack,
           );
           closeConnectionWithError(socket, ERROR_EVENTS.GENERIC_ERROR);
@@ -257,7 +257,7 @@ export class Server {
         }
         // log results
         this.logger.verbose?.(
-          `User '${socket.data.userInfo.email}' read=${socket.data.viewer}, update=${socket.data.collaborator}`,
+          `User '${socket.data.userInfo.id}' read=${socket.data.viewer}, update=${socket.data.collaborator}`,
         );
 
         // load snapshot
@@ -290,7 +290,7 @@ export class Server {
 
             this.utilService.reportChanges(
               roomID,
-              socket.data.userInfo.email,
+              socket.data.userInfo.id,
               (this.snapshots.get(roomID)?.content.elements ??
                 []) as ExcalidrawElement[],
               eventData.payload.elements as ExcalidrawElement[],
@@ -385,11 +385,10 @@ export class Server {
         if (lastContributed >= windowStart && windowEnd >= lastContributed) {
           return {
             id: socket.data.userInfo.id,
-            email: socket.data.userInfo.email,
           };
         }
       })
-      .filter((item): item is { id: string; email: string } => !!item);
+      .filter((item): item is { id: string } => !!item);
 
     this.logger.verbose?.(
       `Registering contributions for ${users.length} users in room '${roomId}'`,
@@ -437,7 +436,7 @@ export class Server {
   private createCollaboratorInactivityTracker(socket: SocketIoSocket) {
     const cb = () => {
       this.logger.verbose?.(
-        `User '${socket.data.userInfo.email}' was inactive ${this.collaboratorInactivityMs / 1000} seconds, setting collaborator mode to 'read' for user '${socket.data.userInfo.email}'`,
+        `User '${socket.data.userInfo.id}' was inactive ${this.collaboratorInactivityMs / 1000} seconds, setting collaborator mode to 'read' for user '${socket.data.userInfo.id}'`,
       );
       // User is inactive, setting collaborator mode to 'read'
       // todo move emit, removeAllListeners, socket.data
@@ -460,11 +459,11 @@ export class Server {
     })().catch((e) => {
       if (isAbortError(e)) {
         this.logger.verbose?.(
-          `Collaborator inactivity tracker for user '${socket.data.userInfo.email}' was aborted with reason '${e.cause}'`,
+          `Collaborator inactivity tracker for user '${socket.data.userInfo.id}' was aborted with reason '${e.cause}'`,
         );
       } else {
         this.logger.error?.(
-          `Collaborator inactivity tracker for user '${socket.data.userInfo.email}' failed: ${e.message}`,
+          `Collaborator inactivity tracker for user '${socket.data.userInfo.id}' failed: ${e.message}`,
         );
       }
     });
@@ -485,7 +484,7 @@ export class Server {
     this.collaboratorInactivityTrackers.set(socket.id, abortController);
     if (logging) {
       this.logger.verbose?.(
-        `Created collaborator inactivity tracker for user '${socket.data.userInfo.email}'`,
+        `Created collaborator inactivity tracker for user '${socket.data.userInfo.id}'`,
       );
     }
   }
@@ -501,7 +500,7 @@ export class Server {
 
       if (logging) {
         this.logger.verbose?.(
-          `Deleted collaborator inactivity tracker for user '${socket.data.userInfo.email}'`,
+          `Deleted collaborator inactivity tracker for user '${socket.data.userInfo.id}'`,
         );
       }
     }
@@ -550,18 +549,18 @@ export class Server {
     })().catch((e) => {
       if (isAbortError(e)) {
         this.logger.verbose?.(
-          `Permission check tracker for user '${socket.data.userInfo.email}' was aborted with reason '${e.cause}'`,
+          `Permission check tracker for user '${socket.data.userInfo.id}' was aborted with reason '${e.cause}'`,
         );
       } else {
         this.logger.error?.(
-          `Permission check tracker for user '${socket.data.userInfo.email}' failed: ${e.message}`,
+          `Permission check tracker for user '${socket.data.userInfo.id}' failed: ${e.message}`,
         );
       }
     });
 
     this.permissionCheckTrackers.set(socket.id, ac);
     this.logger.verbose?.(
-      `Started permission check tracker for user '${socket.data.userInfo.email}' in room '${roomId}'`,
+      `Started permission check tracker for user '${socket.data.userInfo.id}' in room '${roomId}'`,
     );
   }
 
@@ -579,7 +578,7 @@ export class Server {
     // if read access was revoked, disconnect the socket
     if (!canRead) {
       this.logger.warn?.(
-        `User '${socket.data.userInfo.email}' read access revoked for room '${roomId}' - disconnecting`,
+        `User '${socket.data.userInfo.id}' read access revoked for room '${roomId}' - disconnecting`,
       );
       this.deletePermissionCheckTrackerForSocket(socket);
       closeConnectionWithError(socket, ERROR_EVENTS.ROOM_NO_READ_ACCESS);
@@ -589,7 +588,7 @@ export class Server {
     // if update access was revoked but user was a collaborator, downgrade to read-only
     if (!canUpdate && socket.data.collaborator) {
       this.logger.warn?.(
-        `User '${socket.data.userInfo.email}' update access revoked for room '${roomId}' - setting to read-only`,
+        `User '${socket.data.userInfo.id}' update access revoked for room '${roomId}' - setting to read-only`,
       );
       socket.data.collaborator = false;
       socket.removeAllListeners(SERVER_BROADCAST);
@@ -607,7 +606,7 @@ export class Server {
       abortController.abort('deleted');
       this.permissionCheckTrackers.delete(socket.id);
       this.logger.verbose?.(
-        `Deleted permission check tracker for user '${socket.data.userInfo.email}'`,
+        `Deleted permission check tracker for user '${socket.data.userInfo.id}'`,
       );
     }
   }
@@ -622,7 +621,7 @@ export class Server {
       },
     };
     this.wsServer.to(socket.id).emit(SCENE_INIT, jsonToArrayBuffer(data));
-    this.logger.verbose?.(`Scene init sent to '${socket.data.userInfo.email}'`);
+    this.logger.verbose?.(`Scene init sent to '${socket.data.userInfo.id}'`);
   }
 
   // todo: move to a helper class

--- a/src/excalidraw-backend/utils/handlers.ts
+++ b/src/excalidraw-backend/utils/handlers.ts
@@ -46,6 +46,7 @@ export const authorizeWithRoomOrFailAndJoinHandler = async (
   logger: LoggerService,
   getRoomInfo: (
     roomId: string,
+    /** Actor ID (interchangeable with user ID) */
     userId: string,
     guestName?: string,
   ) => Promise<UserInfoForRoom>,
@@ -126,7 +127,7 @@ export const serverBroadcastEventHandler = (
   roomID: string,
   data: ArrayBuffer,
   socket: SocketIoSocket,
-  registerContentModified: (roomId: string, userId: string) => void,
+  registerContentModified: (roomId: string, /** Actor ID (interchangeable with user ID) */ userId: string) => void,
 ) => {
   if (socket.data.lastContributed === -1) {
     registerContentModified(roomID, socket.data.userInfo.id);

--- a/src/excalidraw-backend/utils/handlers.ts
+++ b/src/excalidraw-backend/utils/handlers.ts
@@ -127,7 +127,10 @@ export const serverBroadcastEventHandler = (
   roomID: string,
   data: ArrayBuffer,
   socket: SocketIoSocket,
-  registerContentModified: (roomId: string, /** Actor ID (interchangeable with user ID) */ userId: string) => void,
+  registerContentModified: (
+    roomId: string,
+    /** Actor ID (interchangeable with user ID) */ userId: string,
+  ) => void,
 ) => {
   if (socket.data.lastContributed === -1) {
     registerContentModified(roomID, socket.data.userInfo.id);

--- a/src/excalidraw-backend/utils/handlers.ts
+++ b/src/excalidraw-backend/utils/handlers.ts
@@ -71,11 +71,11 @@ export const authorizeWithRoomOrFailAndJoinHandler = async (
 
   if (isCollaboratorLimitReached) {
     logger.verbose?.(
-      `Max collaborators limit (${maxCollaboratorsForThisRoom}) reached for room '${roomID}' - user '${userInfo.email}' is read-only`,
+      `Max collaborators limit (${maxCollaboratorsForThisRoom}) reached for room '${roomID}' - user '${userInfo.id}' is read-only`,
     );
   } else {
     logger.verbose?.(
-      `Max collaborators limit NOT reached (${collaboratorsInRoom}/${maxCollaboratorsForThisRoom}) for room '${roomID}' - user '${userInfo.email}' is a collaborator`,
+      `Max collaborators limit NOT reached (${collaboratorsInRoom}/${maxCollaboratorsForThisRoom}) for room '${roomID}' - user '${userInfo.id}' is a collaborator`,
     );
   }
 
@@ -111,7 +111,7 @@ const joinRoomHandler = async (
 
   const { userInfo } = socket.data;
 
-  logger?.verbose?.(`User '${userInfo.email}' has joined room '${roomID}'`);
+  logger?.verbose?.(`User '${userInfo.id}' has joined room '${roomID}'`);
 
   const socketIDs = (await fetchSocketsSafe(wsServer, roomID, logger)).map(
     (socket) => socket.id,
@@ -173,7 +173,7 @@ export const disconnectingEventHandler = async (
   socket: SocketIoSocket,
   logger: LoggerService,
 ) => {
-  logger?.verbose?.(`User '${socket.data.userInfo.email}' has disconnected`);
+  logger?.verbose?.(`User '${socket.data.userInfo.id}' has disconnected`);
   for (const roomID of socket.rooms) {
     const otherClientIds = (await fetchSocketsSafe(wsServer, roomID, logger))
       .filter((_socket) => _socket.id !== socket.id)

--- a/src/services/util/util.service.ts
+++ b/src/services/util/util.service.ts
@@ -80,6 +80,7 @@ export class UtilService {
   }
 
   public getUserInfoForRoom(
+    /** Actor ID (interchangeable with user ID) */
     userId: string,
     roomId: string,
     guestName?: string,
@@ -89,6 +90,7 @@ export class UtilService {
     );
   }
 
+  /** @param userId - Actor ID (interchangeable with user ID) */
   public contentModified(userId: string, roomId: string) {
     return this.integrationService.contentModified(
       new ContentModifiedInputData(userId, roomId),

--- a/src/services/util/util.service.ts
+++ b/src/services/util/util.service.ts
@@ -53,7 +53,7 @@ export class UtilService {
         new WhoInputData({ authorization }),
       );
 
-      if (authorizationResult.id && authorizationResult.email) {
+      if (authorizationResult.id) {
         return authorizationResult;
       }
     }
@@ -63,7 +63,7 @@ export class UtilService {
       const cookieResult = await this.integrationService.who(
         new WhoInputData({ cookie }),
       );
-      if (cookieResult.id && cookieResult.email) {
+      if (cookieResult.id) {
         return cookieResult;
       }
     }
@@ -76,7 +76,7 @@ export class UtilService {
       );
     }
 
-    return { id: '', email: '', guestName: '' };
+    return { id: '', guestName: '' };
   }
 
   public getUserInfoForRoom(
@@ -95,7 +95,7 @@ export class UtilService {
     );
   }
 
-  public contribution(roomId: string, users: { id: string; email: string }[]) {
+  public contribution(roomId: string, users: { id: string }[]) {
     return this.integrationService.contribution(
       new ContributionInputData(roomId, users),
     );

--- a/src/services/whiteboard-integration/inputs/content.modified.input.data.ts
+++ b/src/services/whiteboard-integration/inputs/content.modified.input.data.ts
@@ -7,7 +7,7 @@ export class ContentModifiedInputData extends BaseInputData {
   /**
    * Creates a new ContentModifiedInputData instance.
    *
-   * @param {string} triggeredBy - The user that triggered the content modification.
+   * @param {string} triggeredBy - The actor ID (interchangeable with user ID) that triggered the content modification.
    * @param {string} whiteboardId - The ID of the whiteboard where the content was modified.
    */
   constructor(

--- a/src/services/whiteboard-integration/inputs/contribution.input.data.ts
+++ b/src/services/whiteboard-integration/inputs/contribution.input.data.ts
@@ -3,7 +3,7 @@ import { BaseInputData } from './base.input.data';
 export class ContributionInputData extends BaseInputData {
   constructor(
     public whiteboardId: string,
-    public users: { id: string; email: string }[],
+    public users: { id: string }[],
   ) {
     super('contribution');
   }

--- a/src/services/whiteboard-integration/inputs/info.input.data.ts
+++ b/src/services/whiteboard-integration/inputs/info.input.data.ts
@@ -2,6 +2,7 @@ import { BaseInputData } from './base.input.data';
 
 export class InfoInputData extends BaseInputData {
   constructor(
+    /** Actor ID (interchangeable with user ID) */
     public userId: string,
     public whiteboardId: string,
     public guestName?: string,

--- a/src/services/whiteboard-integration/user.info.ts
+++ b/src/services/whiteboard-integration/user.info.ts
@@ -1,4 +1,9 @@
+/**
+ * Represents an actor (user) in the system.
+ * The `id` field is the actor ID; "user ID" and "actor ID" are interchangeable.
+ */
 export type UserInfo = {
+  /** Actor ID (interchangeable with user ID) */
   id: string;
   guestName?: string;
 };

--- a/src/services/whiteboard-integration/user.info.ts
+++ b/src/services/whiteboard-integration/user.info.ts
@@ -1,5 +1,4 @@
 export type UserInfo = {
   id: string;
-  email: string;
   guestName?: string;
 };

--- a/src/services/whiteboard-integration/whiteboard.integration.adapter.service.ts
+++ b/src/services/whiteboard-integration/whiteboard.integration.adapter.service.ts
@@ -91,14 +91,15 @@ export class WhiteboardIntegrationAdapterService {
     );
   }
 
-  public async who(data: WhoInputData) {
-    return this.sendWithResponse<UserInfo, WhoInputData>(
+  public async who(data: WhoInputData): Promise<UserInfo> {
+    return this.sendWithResponse<string, WhoInputData>(
       WhiteboardIntegrationMessagePattern.WHO,
       data,
-    ).catch(() => ({
-      id: 'N/A',
-      email: 'N/A',
-    }));
+    )
+      .then((id) => ({ id: id || '' }))
+      .catch(() => ({
+        id: 'N/A',
+      }));
   }
 
   public async info(data: InfoInputData) {

--- a/src/services/whiteboard-integration/whiteboard.integration.adapter.service.ts
+++ b/src/services/whiteboard-integration/whiteboard.integration.adapter.service.ts
@@ -98,7 +98,7 @@ export class WhiteboardIntegrationAdapterService {
     )
       .then((id) => ({ id: id || '' }))
       .catch(() => ({
-        id: 'N/A',
+        id: '',
       }));
   }
 


### PR DESCRIPTION
- Remove email field from UserInfo type and all related usage
- Switch all log messages to use user ID instead of email
- Update who() to return plain user ID string
- Simplify contribution tracking to only require user ID
- Bump version to 0.10.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.10.0
  * Local diagnostic settings file added to ignore list
* **Refactor**
  * Backend now identifies users by ID instead of email (affects logs and internal tracking)
* **Integration**
  * External integration payloads/responses and contribution inputs no longer include user email; rely on IDs instead
<!-- end of auto-generated comment: release notes by coderabbit.ai -->