### PR TITLE
Add multiarch builds to Hetzner deployment workflows

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -11,17 +11,29 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4.1.7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
       - name: 'Login into ACR'
-        uses: azure/docker-login@v2
+        uses: docker/login-action@v3.7.0
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: 'Build & Push image'
-        run: |
-          docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:latest
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -10,17 +10,29 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4.1.7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
       - name: 'Login into ACR'
-        uses: azure/docker-login@v2
+        uses: docker/login-action@v3.7.0
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: 'Build & Push image'
-        run: |
-          docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:latest
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -10,17 +10,29 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4.1.7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.12.0
+
       - name: 'Login into ACR'
-        uses: azure/docker-login@v2
+        uses: docker/login-action@v3.7.0
         with:
-          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: 'Build & Push image'
-        run: |
-          docker build -f Dockerfile . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }} -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:latest
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:latest
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add QEMU + Buildx setup to dev, sandbox, and test Hetzner deployment workflows
- Replace `azure/docker-login` with `docker/login-action` and `docker build`/`docker push` with `docker/build-push-action`
- Build for both `linux/amd64` and `linux/arm64` platforms, matching the Docker Hub release workflow

## Test plan
- [ ] Verify CI workflow syntax is valid (push triggers no YAML parse errors)
- [ ] Trigger a manual run on sandbox or test to confirm multiarch image is pushed to ACR

🤖 Generated with [Claude Code](https://claude.com/claude-code)