### PR TITLE
fix: add type guard in config value coercion

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -34,19 +34,19 @@ function buildYamlNodeValue(nodeValue: any, envConfig: any) {
 
     updatedNodeValue = envConfig[envVariableKey] ?? envVariableDefaultValue;
 
-    if (updatedNodeValue.toLowerCase() === 'true') {
-      return true;
-    }
-    if (updatedNodeValue.toLowerCase() === 'false') {
-      return false;
-    }
-    if (
-      typeof updatedNodeValue === 'string' &&
-      updatedNodeValue.trim() !== ''
-    ) {
-      const numericValue = Number(updatedNodeValue);
-      if (!Number.isNaN(numericValue)) {
-        return numericValue;
+    if (typeof updatedNodeValue === 'string') {
+      const normalizedValue = updatedNodeValue.toLowerCase();
+      if (normalizedValue === 'true') {
+        return true;
+      }
+      if (normalizedValue === 'false') {
+        return false;
+      }
+      if (updatedNodeValue.trim() !== '') {
+        const numericValue = Number(updatedNodeValue);
+        if (!Number.isNaN(numericValue)) {
+          return numericValue;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Wraps boolean and numeric coercion logic in `buildYamlNodeValue` with a `typeof === 'string'` check to prevent `TypeError` when the resolved value is `undefined`
- Extracts `normalizedValue` to avoid redundant `.toLowerCase()` calls

## Test plan
- [ ] Verify service starts correctly with all env variables set
- [ ] Verify service starts correctly with missing env variables that have YAML defaults
- [ ] Verify service starts correctly with missing env variables that have no defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration value handling to prevent potential runtime errors when processing non-string inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->