### PR TITLE
feat: reload open rooms live on external content writes (workspace#006)

### DIFF
--- a/src/excalidraw-backend/server.module.ts
+++ b/src/excalidraw-backend/server.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { UtilModule } from '../services/util/util.module';
 import { WhiteboardIntegrationModule } from '../services/whiteboard-integration/whiteboard.integration.module';
 import { Server } from './server';
+import { WhiteboardCollaborationController } from './whiteboard.collaboration.controller';
 
 @Module({
   imports: [WhiteboardIntegrationModule, UtilModule],
+  controllers: [WhiteboardCollaborationController],
   providers: [Server],
 })
 export class ServerModule {}

--- a/src/excalidraw-backend/server.ts
+++ b/src/excalidraw-backend/server.ts
@@ -18,6 +18,7 @@ import {
   initUserDataMiddleware,
 } from './middlewares';
 import {
+  CLIENT_BROADCAST,
   COLLABORATOR_MODE,
   CONNECTION,
   CollaboratorModeReasons,
@@ -45,8 +46,9 @@ import {
   SocketEventData,
   SocketIoServer,
   SocketIoSocket,
+  WS_SUBTYPES,
 } from './types';
-import { SceneInitPayload, ServerBroadcastPayload } from './types/events';
+import { SceneInitPayload, SceneReloadPayload, ServerBroadcastPayload } from './types/events';
 import { UnauthorizedReadAccess } from './types/exceptions';
 import {
   authorizeWithRoomOrFailAndJoinHandler,
@@ -625,6 +627,56 @@ export class Server {
     };
     this.wsServer.to(socket.id).emit(SCENE_INIT, jsonToArrayBuffer(data));
     this.logger.verbose?.(`Scene init sent to '${socket.data.userInfo.id}'`);
+  }
+
+  /**
+   * Reloads a room's snapshot from the DB and pushes the fresh scene to every
+   * connected client. Triggered by the server after a direct (external) content
+   * write — e.g. the MCP `update_whiteboard_content` tool — so an OPEN board
+   * reflects the change live instead of only after the next save/reopen.
+   *
+   * If no live snapshot exists for the room, there is nothing to push (no one is
+   * editing it) and we return early. Otherwise we drop the stale in-memory
+   * snapshot and reload it from the DB BEFORE broadcasting — this is what stops
+   * the next throttled saveRoom from clobbering the external write — then emit a
+   * CLIENT_BROADCAST carrying a SCENE_RELOAD subtype. The Redis adapter fans the
+   * broadcast across all collaboration-service instances.
+   *
+   * @param roomId The whiteboard id (roomId === whiteboard.id).
+   */
+  public async reloadRoomFromStore(roomId: string): Promise<void> {
+    if (!isRoomId(roomId)) {
+      return;
+    }
+
+    // Nothing to do if no one has this room open on any instance.
+    if (!this.snapshots.has(roomId)) {
+      const sockets = await this.fetchSocketsSafe(roomId);
+      if (sockets.length === 0) {
+        this.logger.verbose?.(
+          `reloadRoomFromStore: room '${roomId}' has no live snapshot or sockets - skipping`,
+        );
+        return;
+      }
+    }
+
+    // Drop the stale snapshot and re-fetch the DB content into a fresh one. Doing
+    // this BEFORE the broadcast is what prevents the next saveRoom from
+    // overwriting the external write with stale in-memory content.
+    this.snapshots.delete(roomId);
+    const snapshot = await this.loadSnapshot(roomId);
+
+    const data: SceneReloadPayload = {
+      type: WS_SUBTYPES.RELOAD,
+      payload: {
+        elements: snapshot.content.elements,
+        files: snapshot.content.files,
+      },
+    };
+    this.wsServer.in(roomId).emit(CLIENT_BROADCAST, jsonToArrayBuffer(data));
+    this.logger.verbose?.(
+      `reloadRoomFromStore: SCENE_RELOAD broadcast to room '${roomId}' (${snapshot.content.elements.length} elements)`,
+    );
   }
 
   // todo: move to a helper class

--- a/src/excalidraw-backend/types/event.names.ts
+++ b/src/excalidraw-backend/types/event.names.ts
@@ -28,6 +28,10 @@ export const PING = 'ping';
 // These are message subtypes that identify the type of data being broadcast
 export enum WS_SUBTYPES {
   UPDATE = 'SCENE_UPDATE',
+  // Server-initiated full-scene reload after an external (e.g. MCP) content
+  // write. Reconciled by clients exactly like SCENE_UPDATE (NOT SCENE_INIT,
+  // which is the one-time join handler that bypasses the client echo-guard).
+  RELOAD = 'SCENE_RELOAD',
   MOUSE_LOCATION = 'MOUSE_LOCATION',
   IDLE_STATUS = 'IDLE_STATUS',
   EMOJI_REACTION = 'EMOJI_REACTION',

--- a/src/excalidraw-backend/types/events/index.ts
+++ b/src/excalidraw-backend/types/events/index.ts
@@ -2,4 +2,5 @@ export * from './countdown.timer.payload';
 export * from './emoji.reaction.payload';
 export * from './idle.state.payload';
 export * from './scene.init.payload';
+export * from './scene.reload.payload';
 export * from './server.broadcast.payload';

--- a/src/excalidraw-backend/types/events/scene.reload.payload.ts
+++ b/src/excalidraw-backend/types/events/scene.reload.payload.ts
@@ -1,0 +1,17 @@
+import { WS_SUBTYPES } from '../event.names';
+import { DeepReadonly } from '../../utils';
+import { ExcalidrawElement } from '../../../excalidraw/types/excalidraw.element';
+import { ExcalidrawFileStore } from '../../../excalidraw/types/excalidraw.file';
+
+/**
+ * Payload for a server-initiated full-scene reload, broadcast to a room after an
+ * external (e.g. MCP) content write. Carries the freshly reloaded DB scene. The
+ * client reconciles it exactly like a SCENE_UPDATE.
+ */
+export type SceneReloadPayload = {
+  type: WS_SUBTYPES.RELOAD;
+  payload: {
+    elements: readonly ExcalidrawElement[];
+    files: DeepReadonly<ExcalidrawFileStore>;
+  };
+};

--- a/src/excalidraw-backend/whiteboard.collaboration.controller.ts
+++ b/src/excalidraw-backend/whiteboard.collaboration.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Inject, LoggerService } from '@nestjs/common';
+import { EventPattern, Payload, Transport } from '@nestjs/microservices';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { WhiteboardIntegrationEventPattern } from '../services/whiteboard-integration/event.pattern.enum';
+import { Server } from './server';
+
+type ContentUpdatedExternallyData = {
+  whiteboardId: string;
+};
+
+/**
+ * Inbound RMQ listener (server -> this service). Consumes the
+ * `contentUpdatedExternally` event the server emits after a direct content write
+ * (e.g. the MCP `update_whiteboard_content` tool) and asks the Excalidraw server
+ * to reload the affected room from the DB and push the new scene to live editors.
+ *
+ * This is the FIRST inbound microservice listener in this service; everything
+ * else here is an outbound ClientProxy (request/response towards the server).
+ */
+@Controller()
+export class WhiteboardCollaborationController {
+  constructor(
+    private readonly server: Server,
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService,
+  ) {}
+
+  @EventPattern(
+    WhiteboardIntegrationEventPattern.CONTENT_UPDATED_EXTERNALLY,
+    Transport.RMQ,
+  )
+  async contentUpdatedExternally(
+    @Payload() data: ContentUpdatedExternallyData,
+  ): Promise<void> {
+    const whiteboardId = data?.whiteboardId;
+    if (!whiteboardId) {
+      this.logger.warn?.(
+        'Received contentUpdatedExternally event without a whiteboardId',
+      );
+      return;
+    }
+
+    this.logger.verbose?.(
+      `Received contentUpdatedExternally for whiteboard '${whiteboardId}' - reloading room from store`,
+    );
+
+    try {
+      await this.server.reloadRoomFromStore(whiteboardId);
+    } catch (e: any) {
+      this.logger.error?.(
+        `Failed to reload room '${whiteboardId}' from store: ${e?.message}`,
+        e?.stack,
+      );
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,14 @@
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { AppModule } from './app.module';
 import { ConfigType } from './config';
+
+// Dedicated inbound queue consumed ONLY by this service (server -> collaboration).
+// MUST match MessagingQueue.WHITEBOARD_COLLABORATION on the server. It is NOT the
+// outbound queue (alkemio-whiteboards) which the server itself consumes.
+const WHITEBOARD_COLLABORATION_QUEUE = 'alkemio-whiteboard-collaboration';
 
 (async () => {
   const app = await NestFactory.create(AppModule, {
@@ -18,10 +24,34 @@ import { ConfigType } from './config';
   app.useLogger(logger);
 
   const configService: ConfigService<ConfigType, true> = app.get(ConfigService);
-  const port = configService.get('settings.rest.port', {
+
+  // Reuse the exact rabbitmq connection the integration adapter already reads —
+  // do not hardcode creds.
+  const { host, port, user, password, heartbeat } = configService.get(
+    'rabbitmq.connection',
+    { infer: true },
+  );
+  const amqpUrl = `amqp://${user}:${password}@${host}:${port}?heartbeat=${heartbeat}`;
+
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.RMQ,
+    options: {
+      urls: [amqpUrl],
+      queue: WHITEBOARD_COLLABORATION_QUEUE,
+      queueOptions: { durable: true },
+      noAck: true,
+    },
+  });
+
+  await app.startAllMicroservices();
+  logger.verbose?.(
+    `Inbound RMQ microservice listening on queue '${WHITEBOARD_COLLABORATION_QUEUE}'`,
+  );
+
+  const restPort = configService.get('settings.rest.port', {
     infer: true,
   });
-  await app.listen(port, () => {
-    logger.verbose?.(`Rest endpoint running on port ${port}`);
+  await app.listen(restPort, () => {
+    logger.verbose?.(`Rest endpoint running on port ${restPort}`);
   });
 })();

--- a/src/services/whiteboard-integration/event.pattern.enum.ts
+++ b/src/services/whiteboard-integration/event.pattern.enum.ts
@@ -2,4 +2,7 @@ export enum WhiteboardIntegrationEventPattern {
   CONTRIBUTION = 'contribution',
   CONTENT_MODIFIED = 'contentModified',
   SAVE = 'save',
+  // Inbound: server -> this service. Emitted after a direct content write (e.g.
+  // via the MCP update_whiteboard_content tool) so an open room reloads from DB.
+  CONTENT_UPDATED_EXTERNALLY = 'contentUpdatedExternally',
 }


### PR DESCRIPTION
## Summary

The **whiteboard-collaboration-service** slice of
`workspace#006-whiteboard-live-external-writes` (spec: alkem-io/agents-hq#13).

When a whiteboard is written **out-of-band** (e.g. the MCP `update_whiteboard_content` tool —
the AI assistant is one consumer; this is a general external-write mechanism), any **open**
Excalidraw room must reflect it live. This adds:

- the service's **first inbound RMQ listener** (`connectMicroservice` + `startAllMicroservices`)
- an `@EventPattern('contentUpdatedExternally')` controller → `Server.reloadRoomFromStore`
- `reloadRoomFromStore`: **drop** the stale in-memory snapshot → `loadSnapshot` (re-fetch DB)
  **before** broadcasting → `CLIENT_BROADCAST` **`SCENE_RELOAD`** to the room
- `SceneReloadPayload` + `WS_SUBTYPES.RELOAD`

Pairs with the server emitter (on a **dedicated** `alkemio-whiteboard-collaboration` queue —
the server itself listens on `alkemio-whiteboards`) and the client reconcile.

> **Heads-up:** this branch is well behind `develop` (merge-base ~2026-03-05); the PR **diff
> is just the live-push commit**, but it needs a `develop` merge to be mergeable.

Cross-refs: agents-hq#13 (workspace spec 006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live scene reloads: when content is changed externally, a room’s scene is automatically reloaded and pushed to all connected users so everyone sees the latest state in real time.

* **Bug Fixes**
  * Improved external-update handling with validation, error logging and retry-safe broadcasting to reduce missed or stale updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->