### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}

--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -9,23 +9,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.7.0
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4
 
       - name: 'Login into ACR'
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: 'Build & Push image'
-        uses: docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -40,10 +40,10 @@ jobs:
     needs: build
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -61,7 +61,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/25-whiteboard-collaboration-service-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -8,23 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.7.0
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4
 
       - name: 'Login into ACR'
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: 'Build & Push image'
-        uses: docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -39,10 +39,10 @@ jobs:
     needs: build
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -60,7 +60,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/25-whiteboard-collaboration-service-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ secrets.REGISTRY_LOGIN_SERVER }}/alkemio-whiteboard-collaboration-service:${{ github.sha }}

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -8,23 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.7.0
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4
 
       - name: 'Login into ACR'
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: 'Build & Push image'
-        uses: docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -39,10 +39,10 @@ jobs:
     needs: build
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -60,7 +60,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/25-whiteboard-collaboration-service-deployment-dev.yaml

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read    # Required for actions/checkout
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6
         with:
           # Image name derived from repo name (e.g., alkemio/whiteboard-collaboration-service)
           images: alkemio/${{ github.event.repository.name }}
@@ -31,19 +31,19 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.7.0
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: arc-runner-set
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.23.1'
           cache: 'npm'

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: arc-runner-set
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.23.1'
           cache: 'npm'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: arc-runner-set
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.23.1'
           cache: 'npm'


### PR DESCRIPTION
Bump GitHub Actions to latest releases (org-wide actions audit, 2026-07-21).

| Action | Old | New |
|---|---|---|
| `Azure/k8s-deploy` | v5.1.0 | v7.0.0 |
| `actions/checkout` | v4.3.1 v6 v6.0.3 | v7 |
| `actions/setup-node` | v6.5.0 | v7 |
| `azure/setup-kubectl` | v4.0.1 | v5.1.0 |
| `docker/build-push-action` | v6.19.2 | v7 |
| `docker/login-action` | v3.7.0 | v4 |
| `docker/metadata-action` | v5.10.0 | v6 |
| `docker/setup-buildx-action` | v3.12.0 | v4 |
| `docker/setup-qemu-action` | v3.7.0 | v4 |

Also drops `linux/arm64` from non-production image builds (temp env/PR images are amd64-only; release images stay multi-arch).

Compatibility: all `with:` inputs validated against each action's schema at the target version; bumped actions run on node24 (GitHub-hosted runners OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
