### PR TITLE
ci(027): move CI off legacy arc-runner-set to hosted (workspace#027-arc-v3-runner-migration)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## workspace#027-arc-v3-runner-migration — whiteboard-collaboration-service (C-11 audit-gap, all-hosted)

Moves CI off the legacy org-wide arc-runner-set to ubuntu-latest (ci-test, ci-build, ci-lint). Public repo whose pull_request jobs ran untrusted fork code on the unhardened legacy lane (live R-2), missed by the original council scope. Prerequisite for deleting legacy App 2938395 (runbook H1). Routing checker PASS; all-hosted, may merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, lint, and test checks to run on GitHub-hosted Ubuntu environments.
  * No changes to application functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->