### PR TITLE
build(036): distroless nodejs22-debian13 runtime, digest-pinned

### DIFF
--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -53,8 +53,14 @@ echo "== distroless-image-smoke: $IMAGE =="
 
 # --- user, entrypoint, CMD -------------------------------------------------
 USER_ID="$(docker inspect "$IMAGE" --format '{{.Config.User}}')"
-[ "$USER_ID" = "65532" ] || [ "$USER_ID" = "nonroot" ] ||
-  fail "expected user 65532/nonroot, got '$USER_ID'"
+# Must be NUMERIC: the kubelet cannot resolve a non-numeric image user, so a
+# name form (`nonroot`) makes any Pod with `runAsNonRoot: true` fail admission
+# with "image has non-numeric user (nonroot), cannot verify user is non-root".
+# Proven on k8s-hetzner-sandbox during 036 verification.
+case "$USER_ID" in
+  65532|65532:65532) ;;
+  *) fail "expected numeric user 65532 or 65532:65532, got '$USER_ID' (a non-numeric user breaks runAsNonRoot admission)" ;;
+esac
 pass "runs as user '$USER_ID'"
 
 ENTRYPOINT_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')"

--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# workspace#036-distroless-wave-1 — persisted image-contract regression for
+# whiteboard-collaboration-service (epic alkem-io/infrastructure-operations#2499).
+#
+# Modelled on the shipped workspace#026 server harness. Mechanically asserts:
+#   - runs as UID 65532 (nonroot); entrypoint is the distroless node binary
+#   - CMD == ["dist/main.js"]
+#   - no shell, no package manager reachable as an entrypoint override
+#   - no src/ tree, no ts-node, no @biomejs (dev-dependency leak sentinels)
+#   - config.yml IS present at /app/config.yml (deliberately copied — the app
+#     reads it at boot; its absence is a boot failure, so this is a positive
+#     assertion, not a leak check)
+#   - the runtime dependency graph loads inside the image (socket.io stack)
+#   - the Dockerfile carries no floating FROM (every stage digest-pinned)
+#   - emits IMAGE_DIGEST= / IMAGE_SIZE_BYTES=
+#
+# NOTE on WORKDIR: this image uses /app (the 026 server image used
+# /usr/src/app). Paths below are deliberately /app.
+#
+# NOTE on native modules: this service ships NO native (.node) binaries — its
+# dependency tree (socket.io, amqplib, @elastic/elasticsearch, yaml) is pure
+# JS. socket.io's optional native accelerators `bufferutil` and
+# `utf-8-validate` are NOT installed by `npm ci --omit=dev` against this
+# lockfile (they are optional peer deps of `ws`, unresolved here). The harness
+# probes for them and, when absent, falls back to asserting that the socket.io
+# runtime stack itself loads — the substitution WCS-6 requires. If a native
+# dep is ever added, add it to NATIVE_SENTINELS below.
+#
+# Usage: .docker/distroless-image-smoke.sh <image[:tag]>
+set -euo pipefail
+
+IMAGE="${1:?usage: distroless-image-smoke.sh <image[:tag]>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKERFILE="${DOCKERFILE:-$SCRIPT_DIR/../Dockerfile}"
+
+# Optional native accelerators probed first; see note above.
+NATIVE_SENTINELS=(bufferutil utf-8-validate)
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $*"
+}
+
+run_node() {
+  docker run --rm --entrypoint /nodejs/bin/node "$IMAGE" "$@"
+}
+
+echo "== distroless-image-smoke: $IMAGE =="
+
+# --- user, entrypoint, CMD -------------------------------------------------
+USER_ID="$(docker inspect "$IMAGE" --format '{{.Config.User}}')"
+[ "$USER_ID" = "65532" ] || [ "$USER_ID" = "nonroot" ] ||
+  fail "expected user 65532/nonroot, got '$USER_ID'"
+pass "runs as user '$USER_ID'"
+
+ENTRYPOINT_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')"
+echo "$ENTRYPOINT_JSON" | grep -q '/nodejs/bin/node' ||
+  fail "expected distroless node entrypoint, got $ENTRYPOINT_JSON"
+pass "entrypoint is the distroless node binary"
+
+CMD_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Cmd}}')"
+[ "$CMD_JSON" = '["dist/main.js"]' ] || fail "expected CMD [\"dist/main.js\"], got $CMD_JSON"
+pass "CMD is [\"dist/main.js\"]"
+
+# --- no shell / no package manager -----------------------------------------
+for bin in /bin/sh /bin/bash /usr/bin/sh /usr/bin/bash apk apt apt-get npm pnpm yarn; do
+  if docker run --rm --entrypoint "$bin" "$IMAGE" >/dev/null 2>&1; then
+    fail "expected '$bin' to be absent/unexecutable, but it ran"
+  fi
+done
+pass "no shell / package manager is executable"
+
+# --- no dev-dependency leakage ---------------------------------------------
+HAS_SRC="$(run_node -e "console.log(require('fs').existsSync('/app/src'))")"
+[ "$HAS_SRC" = "false" ] || fail "expected no src/ tree in the runtime image"
+pass "no src/ TypeScript tree"
+
+HAS_TS_NODE="$(run_node -e "console.log(require('fs').existsSync('/app/node_modules/ts-node'))")"
+[ "$HAS_TS_NODE" = "false" ] || fail "expected no ts-node in node_modules"
+pass "no ts-node in node_modules"
+
+# Dev-dependency leak sentinels. `npm ci --omit=dev` removes the *packages*
+# but leaves behind EMPTY scope directories (e.g. node_modules/@biomejs/ with
+# zero entries) — that is an npm bookkeeping artifact, not a leak, and it is
+# present in the pre-change image too. So an existence check on the directory
+# would false-positive; assert on actual CONTENT instead: a leaked package
+# always has entries and a package.json.
+DEV_LEAKS="$(run_node -e "
+const fs=require('fs'), p=require('path');
+const sentinels=['@biomejs','@nestjs/cli','@nestjs/schematics','@nestjs/testing',
+                 'jest','ts-jest','ts-loader','ts-node','tsconfig-paths',
+                 'typescript','husky','lint-staged','supertest'];
+const leaks=[];
+for (const d of sentinels) {
+  const fp=p.join('/app/node_modules', d);
+  if (!fs.existsSync(fp)) continue;
+  let entries=[]; try { entries=fs.readdirSync(fp); } catch {}
+  // real package => has content (and, for unscoped names, a package.json)
+  if (entries.length > 0 || fs.existsSync(p.join(fp,'package.json'))) leaks.push(d);
+}
+console.log(leaks.join(','));
+")"
+[ -z "$DEV_LEAKS" ] || fail "dev dependencies leaked into the runtime image: $DEV_LEAKS"
+pass "no dev-dependency packages in node_modules (empty scope dirs ignored)"
+
+# --- config.yml must BE present --------------------------------------------
+HAS_CONFIG="$(run_node -e "console.log(require('fs').existsSync('/app/config.yml'))")"
+[ "$HAS_CONFIG" = "true" ] ||
+  fail "expected /app/config.yml to be present (the app reads it at boot)"
+pass "/app/config.yml is present"
+
+# --- runtime dependency graph loads ----------------------------------------
+# Prefer the optional native accelerators when installed; otherwise assert the
+# socket.io runtime stack loads (WCS-6 substitution, recorded here in-band).
+NATIVES_PRESENT=1
+for m in "${NATIVE_SENTINELS[@]}"; do
+  PRESENT="$(run_node -e "console.log(require('fs').existsSync('/app/node_modules/$m'))")"
+  if [ "$PRESENT" != "true" ]; then
+    NATIVES_PRESENT=0
+    echo "NOTE: optional native accelerator '$m' is not installed in this image"
+  fi
+done
+
+if [ "$NATIVES_PRESENT" = "1" ]; then
+  NATIVE_OUT="$(run_node -e "$(printf "require('/app/node_modules/%s');" "${NATIVE_SENTINELS[@]}") console.log('natives-ok')")"
+  [ "$NATIVE_OUT" = "natives-ok" ] || fail "expected native sentinels to load, got: $NATIVE_OUT"
+  pass "native sentinels load (${NATIVE_SENTINELS[*]})"
+else
+  # Substitution: assert the shipped runtime stack loads instead.
+  STACK_OUT="$(run_node -e "require('/app/node_modules/socket.io'); require('/app/node_modules/amqplib'); require('/app/node_modules/@elastic/elasticsearch'); require('/app/node_modules/yaml'); console.log('stack-ok')")"
+  [ "$STACK_OUT" = "stack-ok" ] || fail "expected socket.io/amqplib/elasticsearch/yaml to load, got: $STACK_OUT"
+  pass "runtime stack loads (socket.io, amqplib, @elastic/elasticsearch, yaml) — native-sentinel substitution"
+fi
+
+# The image must ship zero native binaries; if that ever changes, the
+# glibc-match between builder and runtime becomes load-bearing and a real
+# native sentinel must be added to NATIVE_SENTINELS above.
+NATIVE_BINARIES="$(run_node -e "
+const fs=require('fs'), p=require('path');
+const out=[];
+(function walk(d){ let e; try { e=fs.readdirSync(d,{withFileTypes:true}); } catch { return; }
+  for (const f of e) { const fp=p.join(d,f.name);
+    if (f.isDirectory()) walk(fp); else if (f.name.endsWith('.node')) out.push(fp); } })('/app/node_modules');
+console.log(out.length);
+")"
+echo "NATIVE_BINARY_COUNT=$NATIVE_BINARIES"
+
+# --- the app's own entrypoint module is loadable ---------------------------
+HAS_MAIN="$(run_node -e "console.log(require('fs').existsSync('/app/dist/main.js'))")"
+[ "$HAS_MAIN" = "true" ] || fail "expected /app/dist/main.js to exist"
+pass "/app/dist/main.js exists"
+
+# --- no floating FROM in the Dockerfile ------------------------------------
+if [ -f "$DOCKERFILE" ]; then
+  UNPINNED="$(grep -E '^[[:space:]]*FROM[[:space:]]' "$DOCKERFILE" | grep -v '@sha256:' || true)"
+  [ -z "$UNPINNED" ] || fail "unpinned (floating) FROM found in $DOCKERFILE:"$'\n'"$UNPINNED"
+  pass "every FROM in $(basename "$DOCKERFILE") is digest-pinned"
+else
+  echo "NOTE: Dockerfile not found at $DOCKERFILE — skipping floating-FROM check"
+fi
+
+# --- identity / size -------------------------------------------------------
+IMAGE_DIGEST="$(docker inspect "$IMAGE" --format '{{.Id}}')"
+IMAGE_SIZE_BYTES="$(docker image inspect "$IMAGE" --format '{{.Size}}')"
+echo "IMAGE_DIGEST=$IMAGE_DIGEST"
+echo "IMAGE_SIZE_BYTES=$IMAGE_SIZE_BYTES"
+
+echo "== distroless-image-smoke: ALL CHECKS PASSED =="

--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -67,26 +67,28 @@ CMD_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Cmd}}')"
 pass "CMD is [\"dist/main.js\"]"
 
 # --- no shell / no package manager -----------------------------------------
-# Probe for EXISTENCE on the filesystem, not exit status. A bare `docker run
-# --entrypoint apk <img>` exits non-zero on an image that HAS a working apk
-# (apk with no args is a usage error), so an exit-status test reports present
-# binaries as absent — it has no detection power. lstat (not existsSync) so a
-# dangling symlink still counts as a hit; Google's :debug variants put the
-# shell at /busybox/sh -> /busybox/busybox.
+# Sweep every PATH-shaped directory instead of probing a fixed denylist of
+# binary names: distroless ships /bin, /sbin, /usr/bin, /usr/sbin (and has no
+# /usr/local/bin or /busybox) EMPTY, so ANY entry appearing in one of them —
+# a shell, a package manager, busybox, anything — is a regression. This
+# closes the two holes the review proved in the earlier checks: (a) an
+# exit-status probe read working binaries as absent (apk with no args exits
+# non-zero), and (b) a fixed path list missed /busybox/sh, where Google's
+# :debug variants actually put the shell. lstat/readdir needs no exec
+# permission and sees dangling symlinks.
 FORBIDDEN="$(run_node -e "
 const fs = require('fs');
-const paths = [
-  '/bin/sh','/bin/bash','/usr/bin/sh','/usr/bin/bash',
-  '/busybox/sh','/busybox/busybox','/bin/busybox','/usr/bin/busybox',
-  '/sbin/apk','/usr/bin/apk','/usr/bin/apt','/usr/bin/apt-get','/usr/bin/dpkg',
-  '/usr/local/bin/npm','/usr/local/bin/npx','/usr/local/bin/yarn','/usr/local/bin/pnpm',
-  '/usr/bin/npm','/usr/bin/yarn','/usr/bin/pnpm',
-];
-const hits = paths.filter(p => { try { fs.lstatSync(p); return true; } catch { return false; } });
+const dirs = ['/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin','/busybox'];
+const hits = [];
+for (const d of dirs) {
+  let entries = [];
+  try { entries = fs.readdirSync(d); } catch { continue; } // absent dir is fine
+  for (const e of entries) hits.push(d + '/' + e);
+}
 console.log(hits.join(','));
 ")"
-[ -z "$FORBIDDEN" ] || fail "shell/package-manager present in runtime image: $FORBIDDEN"
-pass "no shell / package manager present on the filesystem"
+[ -z "$FORBIDDEN" ] || fail "unexpected executables in runtime image PATH dirs: $FORBIDDEN"
+pass "PATH directories are empty (no shell / package manager / any binary)"
 
 # --- no dev-dependency leakage ---------------------------------------------
 HAS_SRC="$(run_node -e "console.log(require('fs').existsSync('/app/src'))")"

--- a/.docker/distroless-image-smoke.sh
+++ b/.docker/distroless-image-smoke.sh
@@ -67,12 +67,26 @@ CMD_JSON="$(docker inspect "$IMAGE" --format '{{json .Config.Cmd}}')"
 pass "CMD is [\"dist/main.js\"]"
 
 # --- no shell / no package manager -----------------------------------------
-for bin in /bin/sh /bin/bash /usr/bin/sh /usr/bin/bash apk apt apt-get npm pnpm yarn; do
-  if docker run --rm --entrypoint "$bin" "$IMAGE" >/dev/null 2>&1; then
-    fail "expected '$bin' to be absent/unexecutable, but it ran"
-  fi
-done
-pass "no shell / package manager is executable"
+# Probe for EXISTENCE on the filesystem, not exit status. A bare `docker run
+# --entrypoint apk <img>` exits non-zero on an image that HAS a working apk
+# (apk with no args is a usage error), so an exit-status test reports present
+# binaries as absent — it has no detection power. lstat (not existsSync) so a
+# dangling symlink still counts as a hit; Google's :debug variants put the
+# shell at /busybox/sh -> /busybox/busybox.
+FORBIDDEN="$(run_node -e "
+const fs = require('fs');
+const paths = [
+  '/bin/sh','/bin/bash','/usr/bin/sh','/usr/bin/bash',
+  '/busybox/sh','/busybox/busybox','/bin/busybox','/usr/bin/busybox',
+  '/sbin/apk','/usr/bin/apk','/usr/bin/apt','/usr/bin/apt-get','/usr/bin/dpkg',
+  '/usr/local/bin/npm','/usr/local/bin/npx','/usr/local/bin/yarn','/usr/local/bin/pnpm',
+  '/usr/bin/npm','/usr/bin/yarn','/usr/bin/pnpm',
+];
+const hits = paths.filter(p => { try { fs.lstatSync(p); return true; } catch { return false; } });
+console.log(hits.join(','));
+")"
+[ -z "$FORBIDDEN" ] || fail "shell/package-manager present in runtime image: $FORBIDDEN"
+pass "no shell / package manager present on the filesystem"
 
 # --- no dev-dependency leakage ---------------------------------------------
 HAS_SRC="$(run_node -e "console.log(require('fs').existsSync('/app/src'))")"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,69 @@
+name: CI Image
+
+# workspace#036-distroless-wave-1 (epic alkem-io/infrastructure-operations#2499)
+#
+# Builds the runtime image and runs the persisted distroless contract
+# regression (.docker/distroless-image-smoke.sh) on every PR/push, so a
+# regression in the image contract — a floating FROM, a root user, a shell
+# creeping back in, dev dependencies leaking past `--omit=dev` — fails CI
+# rather than reaching a cluster.
+#
+# The multiarch job additionally proves both architectures still build:
+# build-release-docker-hub.yml publishes linux/amd64,linux/arm64, and a
+# per-architecture (child) digest pin would silently break the arm64 leg.
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  image-contract:
+    name: Image contract (smoke)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build runtime image (amd64, loaded locally)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: alkemio/whiteboard-collaboration-service:ci-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run distroless image smoke test
+        run: bash .docker/distroless-image-smoke.sh alkemio/whiteboard-collaboration-service:ci-smoke
+
+  multiarch-build:
+    name: Multi-arch build (amd64 + arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Proves the pinned base digests are manifest-list (OCI index) digests.
+      # A per-architecture child digest fails here on the arm64 leg.
+      - name: Build for linux/amd64,linux/arm64
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: alkemio/whiteboard-collaboration-service:ci-multiarch
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -37,8 +37,13 @@ jobs:
           load: true
           platforms: linux/amd64
           tags: alkemio/whiteboard-collaboration-service:ci-smoke
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No GHA cache here. Entries written by the multiarch job below carry
+          # BOTH architectures' layers; restoring them makes `docker inspect
+          # .Size` report the multi-arch total for a single-arch image and the
+          # size gate fails against a correct build (observed in the sibling
+          # collaborative-document-service: 179 MB reported for a 60 MB image).
+          # These jobs run in parallel today, so the contamination is currently
+          # order-dependent rather than guaranteed — which is worse, not better.
 
       - name: Run distroless image smoke test
         run: bash .docker/distroless-image-smoke.sh alkemio/whiteboard-collaboration-service:ci-smoke
@@ -65,5 +70,3 @@ jobs:
           push: false
           platforms: linux/amd64,linux/arm64
           tags: alkemio/whiteboard-collaboration-service:ci-multiarch
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,35 @@
+# ============================================================================
+# whiteboard-collaboration-service — distroless runtime image
+#
+# workspace#036-distroless-wave-1 (epic alkem-io/infrastructure-operations#2499)
+#
+# Both stages are pinned by DIGEST. Every digest below is a top-level
+# MANIFEST-LIST (OCI image index) digest, NOT a per-architecture child digest.
+# `build-release-docker-hub.yml` builds linux/amd64,linux/arm64 — a child
+# digest would pin the build to a single architecture and break the arm64 leg.
+# Re-verify with: docker buildx imagetools inspect <ref>
+#   -> MediaType must be application/vnd.oci.image.index.v1+json, and the
+#      manifest list must include linux/amd64 AND linux/arm64.
+#
+# NOTE FOR FUTURE READERS — DO NOT "HARMONISE" THIS FILE WITH
+# notifications / collaborative-document-service.
+# This repo is the one service in the wave whose Volta pin (22.23.1) has a
+# matching `node:<version>-trixie-slim` builder published, so builder and
+# runtime share the same Debian generation (trixie / Debian 13) and therefore
+# the same glibc. notifications and collaborative-document-service pin Node
+# versions for which no matched trixie builder exists and must keep a bookworm
+# builder against a trixie runtime (plan.md §2.3). That mismatch is deliberate
+# there; this match is deliberate here.
+#
+# Pins resolved 2026-08-05 (both verified as OCI indexes, amd64 + arm64):
+#   node:22.23.1-trixie-slim                     sha256:e6d9a389d34f…
+#   gcr.io/distroless/nodejs22-debian13:nonroot  sha256:939d6f167152…
+# ============================================================================
+
 # ======================
 # Builder stage (dev deps)
 # ======================
-FROM node:22.23.1-bookworm AS builder
+FROM node:22.23.1-trixie-slim@sha256:e6d9a389d34ff9678438af985c9913fbd1eb6ed36e80fea56644f4b4f6dd70ba AS builder
 
 WORKDIR /app
 
@@ -23,7 +51,7 @@ RUN npm run build
 # ======================
 # Prod deps stage (NO dev deps)
 # ======================
-FROM node:22.23.1-bookworm AS prod-deps
+FROM node:22.23.1-trixie-slim@sha256:e6d9a389d34ff9678438af985c9913fbd1eb6ed36e80fea56644f4b4f6dd70ba AS prod-deps
 
 WORKDIR /app
 
@@ -36,7 +64,7 @@ RUN npm ci --omit=dev \
 # ======================
 # Runtime stage (distroless)
 # ======================
-FROM gcr.io/distroless/nodejs22-debian12:nonroot
+FROM gcr.io/distroless/nodejs22-debian13:nonroot@sha256:939d6f1671529d230f50b563578e9b5d206af58f038b10ebd7e1233023d4e167
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3034,12 +3034,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -3259,6 +3253,15 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "peer": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -5637,21 +5640,21 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
-      "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
       "license": "MIT",
       "dependencies": {
-        "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
         "cors": "~2.8.5",
-        "debug": "~4.3.1",
+        "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "ws": "~8.21.0"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -5665,6 +5668,29 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -9771,38 +9797,41 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
       },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
+      "engines": {
+        "node": ">=6.0"
       },
       "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
+        "supports-color": {
           "optional": true
         }
       }
     },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/socket.io/node_modules/debug": {
       "version": "4.4.3",
@@ -10736,9 +10765,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -11198,9 +11227,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13218,11 +13248,6 @@
         "@types/node": "*"
       }
     },
-    "@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
-    },
     "@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -13428,6 +13453,14 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "peer": true
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.33",
@@ -14919,20 +14952,35 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "engine.io": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
-      "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
       "requires": {
-        "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
         "cors": "~2.8.5",
-        "debug": "~4.3.1",
+        "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "ws": "~8.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "engine.io-parser": {
@@ -17721,22 +17769,31 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "ws": {
-          "version": "8.21.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-          "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-          "requires": {}
         }
       }
     },
     "socket.io-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "source-map": {
@@ -18315,9 +18372,9 @@
       "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="
     },
     "undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="
     },
     "undici-types": {
       "version": "6.21.0",
@@ -18637,9 +18694,9 @@
       }
     },
     "ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "requires": {}
     },
     "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,9 +2680,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4586,21 +4586,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -9107,12 +9120,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -9592,14 +9606,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -9611,13 +9625,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10651,17 +10665,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/type-is/node_modules/mime-db": {
@@ -12993,9 +13024,9 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "requires": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       }
@@ -14264,21 +14295,26 @@
       }
     },
     "body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "requires": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "dependencies": {
+        "content-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+          "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+        },
         "debug": {
           "version": "4.4.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -17292,11 +17328,12 @@
       "dev": true
     },
     "qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "requires": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       }
     },
     "querystringify": {
@@ -17620,24 +17657,24 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       }
     },
     "side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       }
     },
     "side-channel-map": {
@@ -18303,15 +18340,20 @@
       "dev": true
     },
     "type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "requires": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "dependencies": {
+        "content-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+          "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
+        },
         "mime-db": {
           "version": "1.54.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",


### PR DESCRIPTION
Part of **workspace#036-distroless-wave-1**, wave 1 of epic alkem-io/infrastructure-operations#2499. Sub-issue: alkem-io/infrastructure-operations#2451.

## What

- Runtime: `gcr.io/distroless/nodejs22-debian12:nonroot` → `nodejs22-debian13:nonroot`; both stages digest-pinned to **manifest-list (OCI index) digests** (this repo builds linux/amd64 + linux/arm64).
- CVE hygiene, not ABI necessity: pure-JS prod deps (socket.io, amqplib, @elastic/elasticsearch, yaml) — zero native modules, zero *.node binaries.
- New `.docker/distroless-image-smoke.sh` (CI-wired): PATH-directory readdir sweep for shells/package managers, with **proven detection power** — verified to FAIL a byte-identical build on `:debug-nonroot` (working `/busybox/sh` at uid 65532) that the naive exit-status check passed green.
- **Bonus from review**: lockfile-only `npm update` cleared **3 fixable transitive CVEs** the original evidence had wrongly recorded as "no in-range fix" — `qs` 6.15.0→6.15.3 (CVE-2026-8723), `body-parser` 2.2.2→2.3.0 (CVE-2026-12590), `@opentelemetry/core` 2.1.0→2.10.0 (CVE-2026-54285). `package.json` untouched; tests 34/34.

## Evidence

- trivy: **14 → 0 fixable HIGH/CRITICAL**, and after the lockfile bump the rescan shows **0 fixable findings of any class** (12 unfixable os-pkgs MEDIUM/LOW remain, recorded not waived). Evidence bundle in the workspace spec (`specs/036-distroless-wave-1/evidence/whiteboard-collaboration-service/`).
- Consumer inventory: 5 (dev-orchestration base+overlays, in-repo manifest, infra-ops base+overlays). None sets command/user/volumes — semantically inert swap.
- Deliberately NOT added: readiness/liveness probes (a commented-out probe block on a mismatched port already exists in dev-orchestration — needs its own follow-up, not a ride-along).

## Deploy impact of merging

Merging to `develop` auto-deploys to **Hetzner dev** only.

Review: 3 rounds (panel → adversarial verification by execution → final gate). Security dimension: pass after fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined, security-focused production image for the collaboration service.
  * Added support for building production images for both amd64 and arm64 architectures.

* **Bug Fixes**
  * Improved runtime image validation, including startup behavior, dependency loading, and required configuration checks.

* **Tests**
  * Added automated smoke tests covering image contents, nonroot execution, native binaries, and runtime loadability.
  * Added continuous image build and validation checks for key code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->