### PR TITLE
0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "whiteboard-collaboration-service",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "whiteboard-collaboration-service",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@elastic/elasticsearch": "8.19.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whiteboard-collaboration-service",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Alkemio Whiteboard Collaboration Service for Excalidraw backend",
   "author": "Alkemio Foundation",
   "private": false,


### PR DESCRIPTION
Version bump ahead of the `develop → main` promotion and the v0.13.0 release.

Carries the distroless runtime migration (#262, workspace#036) and the 019 TypeScript 7 dual-compiler upgrade (#247), plus dependency updates.

Minor rather than major: the TS7 change adds a `typecheck:native` **gate**; build and test remain on the TS 6.0 line for zero emit drift (`build` is still `nest build` on both branches). No runtime behaviour change.

Refs: epic alkem-io/infrastructure-operations#2499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->